### PR TITLE
Update README.md

### DIFF
--- a/tools/gsuite-grant-analyzer/README.md
+++ b/tools/gsuite-grant-analyzer/README.md
@@ -4,16 +4,6 @@ G Suite Grant Analyzer is a tool to export to BigQuery data about all the OAuth 
 
 ## Installation
 
-### Install using pip
-
-To install using pip:
-
-```
-pip install --user gsuite-grant-analyzer
-```
-
-The required packages should be downloaded and installed automatically.
-
 ### Manual install
 
 Install the Python Google API Client and BigQuery Client libraries:


### PR DESCRIPTION
Removing obsolete/invalid pip instructions.
The gsuite-grant-analyzer does not exist on pypi.org, and is therefore a security risk.